### PR TITLE
Multiple database support does not work in admin interface

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,11 @@ Multiple database support
 
 Added the ability to specify which database the WordPress content is coming from. Set it using the *WP_DATABASE* setting. Defaults to "default".
 
+
+Database routers need be set to::
+
+    DATABASE_ROUTERS = ['wordpress.router.WordpressRouter']
+
 Default templates
 =================
 

--- a/wordpress/models.py
+++ b/wordpress/models.py
@@ -26,7 +26,6 @@ USER_STATUS_CHOICES = (
 
 READ_ONLY = getattr(settings, "WP_READ_ONLY", True)
 TABLE_PREFIX = getattr(settings, "WP_TABLE_PREFIX", "wp")
-DATABASE = getattr(settings, "WP_DATABASE", "default")
 
 
 #
@@ -45,10 +44,9 @@ class WordPressException(Exception):
 #
 class WordPressManager(models.Manager):
     """
-    Sets the database for all queries.
+    Base manager for wordpress queries.
     """
-    def get_query_set(self, *args, **kwargs):
-        return super(WordPressManager, self).get_query_set(*args, **kwargs).using(DATABASE)
+    pass
 
 
 #

--- a/wordpress/router.py
+++ b/wordpress/router.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+from django.conf import settings
+
+DATABASE = getattr(settings, "WP_DATABASE", "default")
+
+
+class WordpressRouter(object):
+    """
+    Overrides default wordpress database to WP_DATABASE setting.
+    """
+
+    def db_for_read(self, model, **hints):
+        if model._meta.app_label == 'wordpress':
+            return DATABASE
+        return None
+
+    def db_for_write(self, model, **hints):
+        return self.db_for_read(model, **hints)


### PR DESCRIPTION
Page /admin/wordpress/post/1/ triggers error:

```
no such table: wp_users
```

This does not work because ForeignKeyField does not use custom manager.

Default database for application can be changed by database router.
