### PR TITLE
Fix IPAddressField error

### DIFF
--- a/wordpress/models.py
+++ b/wordpress/models.py
@@ -429,7 +429,7 @@ class Comment(WordPressModel):
     author_name = models.CharField(max_length=255, db_column='comment_author')
     author_email = models.EmailField(max_length=100, db_column='comment_author_email')
     author_url = models.URLField(blank=True, db_column='comment_author_url')
-    author_ip = models.IPAddressField(db_column='comment_author_ip')
+    author_ip = models.GenericIPAddressField(db_column='comment_author_ip')
 
     # comment data
     post_date = models.DateTimeField(db_column='comment_date_gmt')


### PR DESCRIPTION
Hey guys,

Thanks much for these models – huge timesaver for me. When installing on Django 1.10, I got the following error, since IPAddressField was removed in 1.9:

```shell
wordpress.Comment.author_ip: (fields.E900) IPAddressField has been removed except for support in historical migrations.
	HINT: Use GenericIPAddressField instead.
```

This PR fixes it...