### PR TITLE
remove permalink decorator

### DIFF
--- a/wordpress/models.py
+++ b/wordpress/models.py
@@ -322,9 +322,8 @@ class Post(WordPressModel):
         self.child_cache = None
         self.term_cache = None
 
-    @models.permalink
     def get_absolute_url(self):
-        return ('wp_object_detail', (
+        return reverse('wp_object_detail', (
             self.post_date.year,
             "%02i" % self.post_date.month,
             "%02i" % self.post_date.day,
@@ -484,9 +483,8 @@ class Term(WordPressModel):
     def __unicode__(self):
         return self.name
 
-    @models.permalink
     def get_absolute_url(self):
-        return ('wp_archive_term', (self.slug, ))
+        return reverse('wp_archive_term', (self.slug, ))
 
 
 class Taxonomy(WordPressModel):

--- a/wordpress/urls.py
+++ b/wordpress/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import *
 from wordpress.views import *
 
-urlpatterns = patterns('wordpress.views',
+urlpatterns = [
 
     url(r'^author/(?P<username>[\w-]+)/$',
         AuthorArchive.as_view(), name='wp_author'),
@@ -29,4 +29,4 @@ urlpatterns = patterns('wordpress.views',
     url(r'^$',
         Archive.as_view(), name='wp_archive_index'),
 
-)
+]


### PR DESCRIPTION
This PR fixes one incompatibility w/ mainline django.

https://docs.djangoproject.com/en/1.11/releases/1.11/#models-permalink-decorator

states to replace deprecated `permalink` decorator and replace w/ a `return reverse(...)`

--timball